### PR TITLE
feat: implement pagination and add query parameter filters to list views across core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,153 +1,107 @@
 # Coleta Premiada
 
-Sistema de gestão para programa de incentivo à reciclagem, onde cidadãos ganham pontos por materiais reciclados que podem ser convertidos em descontos no IPTU.
+Sistema de gestão para programa de incentivo à reciclagem, onde cidadãos ganham pontos por materiais reciclados que podem ser convertidos em benefícios e descontos.
 
 ## 📋 Visão Geral
 
-O Coleta Premiada é uma aplicação distribuída composta por:
-- **Microserviço de Coleta**: Responsável por receber e registrar as pesagens de materiais reciclados
-- **Serviço Core (Monolito)**: Gerencia os cadastros de imóveis, cálculo de descontos e saldos de pontos
-- **Infraestrutura**: Bancos de dados, fila de mensagens e armazenamento de objetos
+O Coleta Premiada é uma plataforma integrada que gerencia o ciclo completo da reciclagem incentivada:
+- **Gestão de Usuários e Roles**: Controle de acesso granular para moradores, supervisores e gestores.
+- **Registro de Coletas**: Lógica para registrar pesagens e materiais recolhidos.
+- **Cálculo de Pontuação**: Business rules para conversão de materiais em pontos.
+- **Auditoria**: Sistema de logs detalhados para todas as ações críticas.
 
 ## 🛠️ Tecnologias Utilizadas
 
-- **Backend**: Python 3.12 com Django
-- **Bancos de Dados**:
-  - PostgreSQL (Core - dados relacionais)
-  - MongoDB (Collection Microservice - documentos)
-- **Mensageria**: RabbitMQ
-- **Armazenamento de Objetos**: MinIO (compatível com S3)
+- **Backend**: Python 3.12 com Django e Django REST Framework
+- **Banco de Dados**: PostgreSQL 16 (Relacional e Auditoria)
+- **Mensageria**: RabbitMQ (Fila de processamento assíncrono)
+- **Task Queue**: Celery
+- **Armazenamento de Objetos**: MinIO (Fotos e evidências)
 - **Orquestração**: Docker Compose
-- **API**: RESTful com Django REST Framework
+- **Auditoria**: Django Auditlog
 
 ## 📁 Estrutura do Projeto
 
 ```
 .
-├── apps/                    # Aplicações frontend (vazio atualmente)
-├── services/                # Serviços backend
-│   ├── collection-microservice/  # Microserviço de coleta (Django)
-│   └── core/                  # Serviço core (Django monolito)
-├── infra/                   # Configurações de infraestrutura
-├── docs/                    # Documentação e diagramas
-├── docker-compose.yml       # Orquestração dos containers
-├── .env.example             # Exemplo de variáveis de ambiente
-└── demo_comunicacao.sh      # Script de demonstração do fluxo
+├── core/                    # Monolito Django (Aplicação Principal)
+│   ├── accounts/            # Gestão de usuários, perfis e roles
+│   ├── collection/          # Registro de coletas e pesagens
+│   ├── program/             # Regras de negócio, pontos e benefícios
+│   ├── messaging/           # Integração com RabbitMQ
+│   └── config/              # Configurações do projeto Django
+├── docs/                    # Documentação, ADRs e Diagramas
+├── docker-compose.yml       # Orquestração de containers
+├── Makefile                 # Atalhos para comandos comuns
+└── .env                     # Variáveis de ambiente (não versionado)
 ```
 
 ## 🚀 Como Iniciar o Projeto
 
 ### Pré-requisitos
 
-- Docker e Docker Compose instalados
-- Porta 8000, 8001, 5432, 27017, 5672, 9000, 9001 disponíveis
+- Docker e Docker Compose instalados.
 
 ### Passo a Passo
 
 1. **Clone o repositório**
    ```bash
-   git clone <repository-url>
-   cd Coleta Premiada
+   git clone https://github.com/rangelro/Coleta-Premiada.git
+   cd Coleta-Premiada
    ```
 
 2. **Configure as variáveis de ambiente**
-   ```bash
-   cp .env.example .env
-   # Edite o .env conforme necessário (especialmente a SECRET_KEY do Django)
-   ```
+   O projeto utiliza um arquivo `.env` na raiz. Certifique-se de que ele contém as chaves necessárias (baseie-se no `core/config/settings.py` para as variáveis esperadas).
 
 3. **Inicie os containers**
    ```bash
    docker compose up -d
    ```
 
-4. **Aguarde a inicialização** (aproximadamente 30 segundos para todos os serviços ficarem prontos)
-
-5. **Verifique se todos os serviços estão rodando**
+4. **Verifique se todos os serviços estão rodando**
    ```bash
-   docker compose ps
+   docker ps
    ```
 
-### Serviços Disponíveis
+### Portas e Acessos
 
-- **API do Microserviço de Coleta**: http://localhost:8001
-- **API do Serviço Core**: http://localhost:8000
-- **Painel do RabbitMQ**: http://localhost:15672 (usuário: rabbit_user, senha: rabbit_senha_local)
-- **Painel do MinIO**: http://localhost:9001 (usuário: minio_admin, senha: minio_senha_local)
-- **Admin do Django**: http://localhost:8000/admin/
+- **API Core**: http://localhost:8001 (Mapeada da porta 8001 interna)
+- **Banco de Dados (PostgreSQL)**: localhost:5433 (Exposta para ferramentas externas)
+- **Painel do RabbitMQ**: http://localhost:15672
+- **Painel do MinIO**: http://localhost:9001
+- **Grafana**: http://localhost:3000
 
-## 📖 Documentação
+## 📖 Documentação Adicional
 
 - [Diagramas de Arquitetura](./docs/diagrams/)
-- [ADR (Architecture Decision Records)](./docs/adr/)
-- [Documentação do Processo de Software](./docs/adr/Processo%20de%20Software%20-%20Coleta%20Premiada.pdf)
+- [ADRs](./docs/adr/)
 
-## 🔄 Fluxo de Funcionamento
-
-1. O coletor envia os dados da pesagem via POST para o Microserviço de Coleta
-2. O Microserviço persiste os dados no MongoDB e publica uma mensagem no RabbitMQ
-3. O Core Consumer lê a mensagem do RabbitMQ, calcula o desconto e salva no PostgreSQL
-4. O saldo de pontos é atualizado e pode ser consultado através da API do Core
-
-## 🧪 Demonstração
-
-Um script de demonstração está disponível para mostrar o fluxo completo:
-
-```bash
-bash demo_comunicacao.sh
-```
-
-Este script irá:
-1. Verificar se todos os containers estão rodando
-2. Simular 3 coletas de diferentes materiais
-3. Mostrar a persistência no MongoDB
-4. Aguardar o processamento pelo Core Consumer
-5. Exibir os resultados no PostgreSQL
-6. Mostrar as regras de negócio aplicadas
-
-## ⚙️ Variáveis de Ambiente
-
-Copie o `.env.example` para `.env` e ajuste conforme necessário:
+## ⚙️ Variáveis de Ambiente Principais
 
 ```env
-# PostgreSQL (banco do Monolito Core)
 POSTGRES_DB=coleta_premiada
 POSTGRES_USER=coleta_user
 POSTGRES_PASSWORD=coleta_senha_local
+POSTGRES_PORT=5432 # Interna do container
 
-# MongoDB (banco do Microserviço de Coleta)
-MONGO_INITDB_DATABASE=coleta_db
-MONGO_USER=mongo_user
-MONGO_PASSWORD=mongo_senha_local
+RABBITMQ_DEFAULT_USER=guest
+RABBITMQ_DEFAULT_PASS=guest
 
-# RabbitMQ (fila de mensagens)
-RABBITMQ_DEFAULT_USER=rabbit_user
-RABBITMQ_DEFAULT_PASS=rabbit_senha_local
-
-# MinIO (armazenamento de fotos)
-MINIO_ROOT_USER=minio_admin
-MINIO_ROOT_PASSWORD=minio_senha_local
-
-# Django
-DJANGO_SECRET_KEY=coloque_aqui_uma_chave_secreta_forte
+DJANGO_SECRET_KEY=chave-secreta-de-desenvolvimento
 DEBUG=True
 ```
 
-## 🐧 Desenvolvimento
+## 🐧 Comandos de Desenvolvimento
 
-Para desenvolver em um dos serviços:
+Use o `Makefile` ou os comandos Docker diretamente:
 
 ```bash
-# Acessar o container do microserviço de coleta
-docker compose exec collection-microservice bash
-
-# Acessar o container do core
-docker compose exec core bash
-
-# Executar migrações (se necessário)
-docker compose exec core python manage.py makemigrations
+# Executar migrações
 docker compose exec core python manage.py migrate
 
-# Criar superuser do Django
+# Criar superusuário
 docker compose exec core python manage.py createsuperuser
+
+# Ver logs do sistema
+docker compose logs -f core
 ```

--- a/core/accounts/models.py
+++ b/core/accounts/models.py
@@ -62,5 +62,5 @@ class Usuario(AbstractBaseUser, PermissionsMixin):
         return f"{self.nome} ({self.perfil})"
 
 
-auditlog.register(Usuario)
+auditlog.register(Usuario, m2m_fields={'roles'})
 auditlog.register(Role)

--- a/core/accounts/views.py
+++ b/core/accounts/views.py
@@ -80,15 +80,12 @@ class AuthCreateView(generics.CreateAPIView):
     queryset = Usuario.objects.all()
 
 
+from config.pagination import StandardResultsSetPagination
+
+
 # ---------------------------------------------------------------------------
 # GERENCIAMENTO DE USUÁRIOS (GESTORES)  /users/*
 # ---------------------------------------------------------------------------
-class StandardResultsSetPagination(PageNumberPagination):
-    page_size = 20
-    page_size_query_param = 'page_size'
-    max_page_size = 100
-
-
 class UserManagerView(generics.ListCreateAPIView):
     """
     🔒 GET  /users — Lista, filtra e pagina usuários (só Gestor).

--- a/core/accounts/views.py
+++ b/core/accounts/views.py
@@ -183,7 +183,9 @@ class RoleDetailView(generics.RetrieveUpdateAPIView):
 
 
 class UsuarioRoleAddView(APIView):
-    """🔒 POST /users/:id/roles/:roleId — vincula um papel a um usuário."""
+    """🔒 POST /users/:id/roles/:roleId — vincula um papel a um usuário.
+       🔒 DELETE /users/:id/roles/:roleId — remove o vínculo de um papel a um usuário.
+    """
     permission_classes = [IsGestor]
 
     def post(self, request, id, roleId):
@@ -197,6 +199,19 @@ class UsuarioRoleAddView(APIView):
 
         usuario.roles.add(role)
         return Response(UsuarioSerializer(usuario).data, status=status.HTTP_200_OK)
+
+    def delete(self, request, id, roleId):
+        try:
+            usuario = Usuario.objects.get(pk=id)
+            role = Role.objects.get(pk=roleId)
+        except (Usuario.DoesNotExist, Role.DoesNotExist):
+            return Response({'detail': 'Usuário ou papel não encontrado.'}, status=404)
+
+        if not usuario.roles.filter(pk=roleId).exists():
+            return Response({'detail': 'Vínculo não encontrado.'}, status=404)
+
+        usuario.roles.remove(role)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 # ---------------------------------------------------------------------------

--- a/core/collection/views.py
+++ b/core/collection/views.py
@@ -25,6 +25,8 @@ from .serializers import (
     ContestacaoUpdateSerializer,
 )
 
+from config.pagination import StandardResultsSetPagination
+
 
 # ---------------------------------------------------------------------------
 # COLETAS  /collections/*
@@ -40,12 +42,31 @@ class ColetaListCreateView(generics.ListCreateAPIView):
     - Gestor/supervisor vê todas.
     """
     serializer_class = RegistroColetaSerializer
+    pagination_class = StandardResultsSetPagination
 
     def get_queryset(self):
-        qs = RegistroColeta.objects.select_related('imovel', 'imovel__titular')
+        qs = RegistroColeta.objects.select_related('imovel', 'imovel__titular').all().order_by('-data_coleta')
         user = self.request.user
         if getattr(user, 'perfil', None) == 'morador':
             qs = qs.filter(imovel__titular=user)
+        
+        # Filtros
+        imovel_id = self.request.query_params.get('imovel_id')
+        if imovel_id:
+            qs = qs.filter(imovel_id=imovel_id)
+            
+        programa_id = self.request.query_params.get('programa_id')
+        if programa_id:
+            qs = qs.filter(programa_id=programa_id)
+            
+        data_inicio = self.request.query_params.get('data_inicio')
+        if data_inicio:
+            qs = qs.filter(data_coleta__date__gte=data_inicio)
+            
+        data_fim = self.request.query_params.get('data_fim')
+        if data_fim:
+            qs = qs.filter(data_coleta__date__lte=data_fim)
+            
         return qs
 
     def get_permissions(self):
@@ -109,6 +130,8 @@ class ContestacaoListCreateView(generics.ListCreateAPIView):
 
     Regra do POST: a coleta precisa pertencer a um imóvel do morador logado.
     """
+    pagination_class = StandardResultsSetPagination
+
     def get_serializer_class(self):
         if self.request.method == 'POST':
             return ContestacaoCreateSerializer
@@ -122,10 +145,16 @@ class ContestacaoListCreateView(generics.ListCreateAPIView):
     def get_queryset(self):
         qs = Contestacao.objects.select_related(
             'coleta', 'aberta_por', 'analisada_por',
-        )
+        ).all().order_by('-data_abertura')
         user = self.request.user
         if getattr(user, 'perfil', None) == 'morador':
             qs = qs.filter(aberta_por=user)
+        
+        # Filtros
+        status_filter = self.request.query_params.get('status')
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+            
         return qs
 
     def perform_create(self, serializer):

--- a/core/collection/views.py
+++ b/core/collection/views.py
@@ -11,6 +11,7 @@ from rest_framework import generics, status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import ValidationError
 
 from accounts.permissions import (
     IsGestor, IsMorador, IsGestorOrSupervisor,
@@ -53,20 +54,34 @@ class ColetaListCreateView(generics.ListCreateAPIView):
         # Filtros
         imovel_id = self.request.query_params.get('imovel_id')
         if imovel_id:
-            qs = qs.filter(imovel_id=imovel_id)
-            
+            try:
+                qs = qs.filter(imovel_id=int(imovel_id))
+            except ValueError:
+                raise ValidationError({'imovel_id': 'Deve ser um número inteiro.'})
+
         programa_id = self.request.query_params.get('programa_id')
         if programa_id:
-            qs = qs.filter(programa_id=programa_id)
-            
+            try:
+                qs = qs.filter(programa_id=int(programa_id))
+            except ValueError:
+                raise ValidationError({'programa_id': 'Deve ser um número inteiro.'})
+
         data_inicio = self.request.query_params.get('data_inicio')
         if data_inicio:
-            qs = qs.filter(data_coleta__date__gte=data_inicio)
-            
+            try:
+                import datetime; datetime.date.fromisoformat(data_inicio)
+            except ValueError:
+                raise ValidationError({'data_inicio': 'Use o formato YYYY-MM-DD.'})
+            qs = qs.filter(data_hora_coleta__date__gte=data_inicio)
+
         data_fim = self.request.query_params.get('data_fim')
         if data_fim:
-            qs = qs.filter(data_coleta__date__lte=data_fim)
-            
+            try:
+                import datetime; datetime.date.fromisoformat(data_fim)
+            except ValueError:
+                raise ValidationError({'data_fim': 'Use o formato YYYY-MM-DD.'})
+            qs = qs.filter(data_hora_coleta__date__lte=data_fim)
+
         return qs
 
     def get_permissions(self):
@@ -145,7 +160,7 @@ class ContestacaoListCreateView(generics.ListCreateAPIView):
     def get_queryset(self):
         qs = Contestacao.objects.select_related(
             'coleta', 'aberta_por', 'analisada_por',
-        ).all().order_by('-data_abertura')
+        ).all().order_by('-aberta_em')
         user = self.request.user
         if getattr(user, 'perfil', None) == 'morador':
             qs = qs.filter(aberta_por=user)

--- a/core/config/pagination.py
+++ b/core/config/pagination.py
@@ -1,0 +1,6 @@
+from rest_framework.pagination import PageNumberPagination
+
+class StandardResultsSetPagination(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = 'page_size'
+    max_page_size = 100

--- a/core/program/views.py
+++ b/core/program/views.py
@@ -33,6 +33,8 @@ from .serializers import (
 )
 from .business_rules import aplicar_teto, DESCONTO_MAXIMO
 
+from config.pagination import StandardResultsSetPagination
+
 
 # ---------------------------------------------------------------------------
 # IMÓVEIS  /properties/*
@@ -43,13 +45,37 @@ class ImovelListCreateView(generics.ListCreateAPIView):
     🔒 POST /properties — cria imóvel e publica adesão na fila.
     """
     serializer_class = ImovelSerializer
+    pagination_class = StandardResultsSetPagination
 
     def get_queryset(self):
-        qs = Imovel.objects.select_related('titular').all()
+        qs = Imovel.objects.select_related('titular').all().order_by('id')
         user = self.request.user
         # Regra de negócio: morador só enxerga seus próprios imóveis.
         if getattr(user, 'perfil', None) == 'morador':
             qs = qs.filter(Q(titular=user) | Q(moradores=user)).distinct()
+        
+        # Filtros administrativos
+        bairro = self.request.query_params.get('bairro')
+        if bairro:
+            qs = qs.filter(bairro__icontains=bairro)
+            
+        cidade = self.request.query_params.get('cidade')
+        if cidade:
+            qs = qs.filter(cidade__icontains=cidade)
+            
+        ativo = self.request.query_params.get('ativo')
+        if ativo is not None:
+            if ativo.lower() == 'true':
+                qs = qs.filter(ativo=True)
+            elif ativo.lower() == 'false':
+                qs = qs.filter(ativo=False)
+                
+        search = self.request.query_params.get('search')
+        if search:
+            qs = qs.filter(
+                Q(inscricao__icontains=search) | Q(titular__nome__icontains=search)
+            )
+
         return qs
 
     def get_permissions(self):
@@ -61,8 +87,8 @@ class ImovelListCreateView(generics.ListCreateAPIView):
 
 class ImovelDetailView(generics.RetrieveUpdateAPIView):
     """
-    🔒 GET   /properties/:id — busca um imóvel.
-    🔒 PATCH /properties/:id — atualiza um imóvel (gestor/supervisor).
+    GET   /properties/:id — busca um imóvel.
+    PATCH /properties/:id — atualiza um imóvel (gestor/supervisor).
     """
     serializer_class = ImovelSerializer
     queryset = Imovel.objects.all()
@@ -74,7 +100,7 @@ class ImovelDetailView(generics.RetrieveUpdateAPIView):
 
 
 class ImovelAddUserView(APIView):
-    """🔒 POST /properties/:id/users — vincula um morador a um imóvel."""
+    """ POST /properties/:id/users — vincula um morador a um imóvel."""
     permission_classes = [IsGestorOrSupervisor]
 
     def post(self, request, id):
@@ -95,7 +121,7 @@ class ImovelAddUserView(APIView):
 
 
 class ImovelRemoveUserView(APIView):
-    """🔒 DELETE /properties/:id/users/:userId — remove um morador do imóvel."""
+    """ DELETE /properties/:id/users/:userId — remove um morador do imóvel."""
     permission_classes = [IsGestorOrSupervisor]
 
     def delete(self, request, id, userId):
@@ -117,8 +143,8 @@ class ImovelRemoveUserView(APIView):
 # ---------------------------------------------------------------------------
 class ProgramaListCreateView(generics.ListCreateAPIView):
     """
-    🔒 GET  /programs — lista programas (qualquer autenticado).
-    🔒 POST /programs — cria programa (somente gestor).
+     GET  /programs — lista programas (qualquer autenticado).
+     POST /programs — cria programa (somente gestor).
     """
     serializer_class = ProgramaSerializer
     queryset = Programa.objects.all().prefetch_related('regras')
@@ -127,8 +153,8 @@ class ProgramaListCreateView(generics.ListCreateAPIView):
 
 class ProgramaDetailView(generics.RetrieveUpdateAPIView):
     """
-    🔒 GET   /programs/:id — detalha um programa.
-    🔒 PATCH /programs/:id — atualiza um programa (gestor).
+     GET   /programs/:id — detalha um programa.
+     PATCH /programs/:id — atualiza um programa (gestor).
     """
     serializer_class = ProgramaSerializer
     queryset = Programa.objects.all().prefetch_related('regras')
@@ -138,8 +164,8 @@ class ProgramaDetailView(generics.RetrieveUpdateAPIView):
 
 class ProgramaRulesView(APIView):
     """
-    🔒 GET   /programs/:id/rules — retorna regras do programa.
-    🔒 PATCH /programs/:id/rules — atualiza regras do programa (gestor).
+     GET   /programs/:id/rules — retorna regras do programa.
+     PATCH /programs/:id/rules — atualiza regras do programa (gestor).
     """
     permission_classes = [ReadOnlyOrGestor]
 
@@ -162,7 +188,7 @@ class ProgramaRulesView(APIView):
 # ---------------------------------------------------------------------------
 class ConsolidacaoRunView(APIView):
     """
-    🔒 POST /consolidations/run — dispara consolidação do programa.
+    POST /consolidations/run — dispara consolidação do programa.
 
     Regras de negócio aplicadas:
     - Apenas gestor pode executar.
@@ -240,14 +266,23 @@ class ConsolidacaoRunView(APIView):
 
 
 class ConsolidacaoListView(generics.ListAPIView):
-    """🔒 GET /consolidations — lista consolidações já executadas."""
+    """ GET /consolidations — lista consolidações já executadas."""
     permission_classes = [IsGestorOrSupervisor]
     serializer_class = ConsolidacaoSerializer
-    queryset = Consolidacao.objects.select_related('programa', 'executada_por')
+    pagination_class = StandardResultsSetPagination
+
+    def get_queryset(self):
+        qs = Consolidacao.objects.select_related('programa', 'executada_por').all().order_by('-data_execucao')
+        
+        programa_id = self.request.query_params.get('programa_id')
+        if programa_id:
+            qs = qs.filter(programa_id=programa_id)
+            
+        return qs
 
 
 class ConsolidacaoDetailView(generics.RetrieveAPIView):
-    """🔒 GET /consolidations/:id — detalhe de uma consolidação."""
+    """ GET /consolidations/:id — detalhe de uma consolidação."""
     permission_classes = [IsGestorOrSupervisor]
     serializer_class = ConsolidacaoSerializer
     queryset = Consolidacao.objects.select_related('programa', 'executada_por')
@@ -257,15 +292,32 @@ class ConsolidacaoDetailView(generics.RetrieveAPIView):
 # BENEFÍCIOS  /benefits/*
 # ---------------------------------------------------------------------------
 class BeneficioListView(generics.ListAPIView):
-    """🔒 GET /benefits — retorna todos os benefícios (saldos) consolidados."""
+    """ GET /benefits — retorna todos os benefícios (saldos) consolidados."""
     permission_classes = [IsGestorOrSupervisor]
     serializer_class = SaldoPontosSerializer
-    queryset = SaldoPontos.objects.select_related('imovel')
+    pagination_class = StandardResultsSetPagination
+
+    def get_queryset(self):
+        qs = SaldoPontos.objects.select_related('imovel').all().order_by('-id')
+        
+        imovel_id = self.request.query_params.get('imovel_id')
+        if imovel_id:
+            qs = qs.filter(imovel_id=imovel_id)
+            
+        programa_id = self.request.query_params.get('programa_id')
+        if programa_id:
+            qs = qs.filter(programa_id=programa_id)
+            
+        ciclo = self.request.query_params.get('ciclo')
+        if ciclo:
+            qs = qs.filter(ciclo=ciclo)
+            
+        return qs
 
 
 class BeneficioDetailView(APIView):
     """
-    🔒 GET /benefits/:propertyId/:programaId — benefícios do imóvel em um programa.
+    GET /benefits/:propertyId/:programaId — benefícios do imóvel em um programa.
 
     Retorna a lista completa de saldos por ciclo e o desconto total acumulado.
     """
@@ -295,7 +347,7 @@ class BeneficioDetailView(APIView):
 # RELATÓRIOS  /reports/*
 # ---------------------------------------------------------------------------
 class ReportParticipationView(APIView):
-    """🔒 GET /reports/participation — quem participou do programa."""
+    """ GET /reports/participation — quem participou do programa."""
     permission_classes = [IsGestorOrSupervisor]
 
     def get(self, request):
@@ -313,12 +365,21 @@ class ReportParticipationView(APIView):
             )
             .order_by('-pontos')
         )
+        
+        programa_id = request.query_params.get('programa_id')
+        if programa_id:
+            participantes = participantes.filter(programa_id=programa_id)
+
+        paginator = StandardResultsSetPagination()
+        page = paginator.paginate_queryset(participantes, request)
+        if page is not None:
+            return paginator.get_paginated_response(page)
         return Response(list(participantes))
 
 
 
 class ReportRankingView(APIView):
-    """🔒 GET /reports/ranking — ranking de imóveis por pontuação."""
+    """ GET /reports/ranking — ranking de imóveis por pontuação."""
     permission_classes = [IsGestorOrSupervisor]
 
     def get(self, request):
@@ -328,13 +389,22 @@ class ReportRankingView(APIView):
             RegistroColeta.objects
             .values('imovel__inscricao', 'imovel__titular__nome')
             .annotate(pontos=Sum('pontuacao'))
-            .order_by('-pontos')[:50]
+            .order_by('-pontos')
         )
+        
+        programa_id = request.query_params.get('programa_id')
+        if programa_id:
+            ranking = ranking.filter(programa_id=programa_id)
+
+        paginator = StandardResultsSetPagination()
+        page = paginator.paginate_queryset(ranking, request)
+        if page is not None:
+            return paginator.get_paginated_response(page)
         return Response(list(ranking))
 
 
 class ReportImpactView(APIView):
-    """🔒 GET /reports/impact — impacto agregado do programa."""
+    """ GET /reports/impact — impacto agregado do programa."""
     permission_classes = [IsGestorOrSupervisor]
 
     def get(self, request):
@@ -362,8 +432,8 @@ class ReportImpactView(APIView):
 # ---------------------------------------------------------------------------
 class ConstantePontuacaoView(APIView):
     """
-    🔒 GET   /scoring-constant — leitura da constante (qualquer autenticado).
-    🔒 PATCH /scoring-constant — atualiza a constante (somente supervisor).
+    GET   /scoring-constant — leitura da constante (qualquer autenticado).
+    PATCH /scoring-constant — atualiza a constante (somente supervisor).
     """
 
     def get_permissions(self):

--- a/core/program/views.py
+++ b/core/program/views.py
@@ -34,6 +34,7 @@ from .serializers import (
 from .business_rules import aplicar_teto, DESCONTO_MAXIMO
 
 from config.pagination import StandardResultsSetPagination
+from rest_framework.exceptions import ValidationError
 
 
 # ---------------------------------------------------------------------------
@@ -272,12 +273,15 @@ class ConsolidacaoListView(generics.ListAPIView):
     pagination_class = StandardResultsSetPagination
 
     def get_queryset(self):
-        qs = Consolidacao.objects.select_related('programa', 'executada_por').all().order_by('-data_execucao')
+        qs = Consolidacao.objects.select_related('programa', 'executada_por').all().order_by('-executada_em')
         
         programa_id = self.request.query_params.get('programa_id')
         if programa_id:
-            qs = qs.filter(programa_id=programa_id)
-            
+            try:
+                qs = qs.filter(programa_id=int(programa_id))
+            except ValueError:
+                raise ValidationError({'programa_id': 'Deve ser um número inteiro.'})
+
         return qs
 
 
@@ -302,16 +306,22 @@ class BeneficioListView(generics.ListAPIView):
         
         imovel_id = self.request.query_params.get('imovel_id')
         if imovel_id:
-            qs = qs.filter(imovel_id=imovel_id)
-            
+            try:
+                qs = qs.filter(imovel_id=int(imovel_id))
+            except ValueError:
+                raise ValidationError({'imovel_id': 'Deve ser um número inteiro.'})
+
         programa_id = self.request.query_params.get('programa_id')
         if programa_id:
-            qs = qs.filter(programa_id=programa_id)
-            
+            try:
+                qs = qs.filter(programa_id=int(programa_id))
+            except ValueError:
+                raise ValidationError({'programa_id': 'Deve ser um número inteiro.'})
+
         ciclo = self.request.query_params.get('ciclo')
         if ciclo:
             qs = qs.filter(ciclo=ciclo)
-            
+
         return qs
 
 
@@ -368,7 +378,10 @@ class ReportParticipationView(APIView):
         
         programa_id = request.query_params.get('programa_id')
         if programa_id:
-            participantes = participantes.filter(programa_id=programa_id)
+            try:
+                participantes = participantes.filter(programa_id=int(programa_id))
+            except ValueError:
+                raise ValidationError({'programa_id': 'Deve ser um número inteiro.'})
 
         paginator = StandardResultsSetPagination()
         page = paginator.paginate_queryset(participantes, request)
@@ -394,7 +407,10 @@ class ReportRankingView(APIView):
         
         programa_id = request.query_params.get('programa_id')
         if programa_id:
-            ranking = ranking.filter(programa_id=programa_id)
+            try:
+                ranking = ranking.filter(programa_id=int(programa_id))
+            except ValueError:
+                raise ValidationError({'programa_id': 'Deve ser um número inteiro.'})
 
         paginator = StandardResultsSetPagination()
         page = paginator.paginate_queryset(ranking, request)


### PR DESCRIPTION
### Issue:  [CORE-ADMIN-2]

## 1. O que foi alterado

### Global
- **Criação da Classe de Paginação Padrão:** Foi criada a classe `StandardResultsSetPagination` em `core/config/pagination.py`, configurada com `page_size=20` e `max_page_size=100`.
- **Centralização:** A definição de paginação que antes estava dispersa (ex: em `accounts/views.py`) foi centralizada para garantir consistência em todo o projeto.

### Endpoints de Programas (`/api/program/`)
- **Imóveis (`/properties`):** Implementada paginação e filtros por bairro, cidade, status (ativo/inativo) e busca geral (inscrição ou nome do titular).
- **Consolidações (`/consolidations`):** Implementada paginação e filtro por `programa_id`.
- **Benefícios (`/benefits`):** Implementada paginação e filtros por `imovel_id`, `programa_id` e `ciclo`.
- **Relatório de Participação (`/reports/participation`):** Implementado filtro por `programa_id` e paginação manual dos resultados agregados.
- **Relatório de Ranking (`/reports/ranking`):** Implementado filtro por `programa_id` e paginação manual (removendo o limite fixo de 50 resultados para permitir navegação completa).

### Endpoints de Coletas (`/api/collection/`)
- **Coletas (`/collections`):** Implementada paginação e filtros por `imovel_id`, `programa_id`, `data_inicio` e `data_fim`.
- **Contestações (`/disputes`):** Implementada paginação e filtro por `status`.

## 2. Como foi alterado

### Estrutura Técnica
- **Paginação:** Utilizou-se o `PageNumberPagination` do Django Rest Framework. Nos endpoints baseados em `ListAPIView` ou `ListCreateAPIView`, bastou definir o atributo `pagination_class`. Nos endpoints baseados em `APIView` (relatórios), a paginação foi disparada manualmente no método `get`.
- **Ordenação:** Para que a paginação funcione de forma consistente, foi adicionada uma ordenação padrão (`order_by`) em todos os querysets paginados (ex: por data decrescente ou ID).
- **Filtragem:** A lógica de filtros foi implementada sobrescrevendo o método `get_queryset` (ou dentro do `get` no caso de `APIView`), capturando os parâmetros da query-string via `self.request.query_params` e aplicando os filtros `.filter()` correspondentes.
- **Preservação de Regras:** As verificações de permissão existentes (ex: Morador só vê seus próprios dados) foram mantidas, com os novos filtros sendo aplicados sobre o queryset já restrito pelo perfil do usuário.


### Issue: [CORE-ADMIN-3]

## 1. O que foi alterado

- **Endpoint de API**: Foi adicionado o suporte ao método `DELETE` na rota `/api/accounts/users/{id}/roles/{roleId}`.
- **Configuração de Auditoria**: O modelo `Usuario` foi re-registrado no `django-auditlog` para incluir o rastreamento do campo `roles` (Many-to-Many).
- **Cobertura de Testes**: Foram adicionados testes unitários e de integração para validar o novo endpoint e a integridade da auditoria.

## 2. Como foi alterado

### Backend (Django/DRF)
- **`core/accounts/views.py`**:
    - Implementação do método `delete` na classe `UsuarioRoleAddView`.
    - Adição de validações para garantir que tanto o `Usuario` quanto a `Role` existam.
    - Verificação explícita da existência do vínculo antes da remoção para garantir o retorno `404` conforme requisito.
- **`core/accounts/models.py`**:
    - Alteração na chamada `auditlog.register(Usuario)` para `auditlog.register(Usuario, m2m_fields={'roles'})`.

