### PR TITLE
Feature/llm report implementando integração com LLM para criação de relatorios

### DIFF
--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -127,8 +127,8 @@ CELERY_ACCEPT_CONTENT = ['json']
 # User-agent enviado ao Nominatim — deve identificar o projeto
 NOMINATIM_USER_AGENT = os.getenv('NOMINATIM_USER_AGENT', 'coleta-premiada/1.0')
 
-# Anthropic API Key
-ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY')
+# DeepSeek API Key
+DEEPSEEK_API_KEY = os.getenv('DEEPSEEK_API_KEY')
 
 # LLM local via LM Studio (OpenAI-compatible)
 LOCAL_LLM_BASE_URL = os.getenv('LOCAL_LLM_BASE_URL', 'http://host.docker.internal:1234')

--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -126,3 +126,6 @@ CELERY_ACCEPT_CONTENT = ['json']
 
 # User-agent enviado ao Nominatim — deve identificar o projeto
 NOMINATIM_USER_AGENT = os.getenv('NOMINATIM_USER_AGENT', 'coleta-premiada/1.0')
+
+# Anthropic API Key
+ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY')

--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -129,3 +129,7 @@ NOMINATIM_USER_AGENT = os.getenv('NOMINATIM_USER_AGENT', 'coleta-premiada/1.0')
 
 # Anthropic API Key
 ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY')
+
+# LLM local via LM Studio (OpenAI-compatible)
+LOCAL_LLM_BASE_URL = os.getenv('LOCAL_LLM_BASE_URL', 'http://host.docker.internal:1234')
+LOCAL_LLM_MODEL = os.getenv('LOCAL_LLM_MODEL', 'google/gemma-4-e2b')

--- a/core/program/management/commands/passo_admin.py
+++ b/core/program/management/commands/passo_admin.py
@@ -1,0 +1,85 @@
+import time
+from decimal import Decimal
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+
+from program.models import Programa, RegraPrograma, Imovel, SaldoPontos, ConstantePontuacao
+from collection.models import RegistroColeta
+
+Usuario = get_user_model()
+
+class Command(BaseCommand):
+    help = 'Preenche o banco de dados de forma idempotente para testes.'
+
+    def handle(self, *args, **options):
+        self.stdout.write("=== INICIANDO CRIAÇÃO DE DADOS DE TESTE ===")
+
+        # 1. Constante
+        constante, c = ConstantePontuacao.objects.get_or_create(
+            pk=1, defaults={'points_por_kg': Decimal('1.5000')}
+        )
+        self.stdout.write(f"✓ Constante de pontuação: {'Criada' if c else 'Já existia'}")
+
+        # 2. Programa
+        hoje = timezone.now().date()
+        programa, c = Programa.objects.get_or_create(
+            nome='Ciclo 2026 - Coleta Verde',
+            defaults={
+                'descricao': 'Teste', 
+                'ativo': True, 
+                'data_inicio': hoje.replace(month=1, day=1), 
+                'data_fim': hoje.replace(month=12, day=31), 
+                'desconto_maximo': Decimal('40.00')
+            }
+        )
+        self.stdout.write(f"✓ Programa {programa.nome}: {'Criado' if c else 'Já existia'}")
+
+        # 3. Regras
+        regra, c = RegraPrograma.objects.get_or_create(
+            programa=programa,
+            defaults={'pontos_por_real': Decimal('10.00'), 'minimo_para_beneficio': 50, 'permite_acumulo_ciclos': False}
+        )
+
+        # 4. Usuário Morador
+        morador, c = Usuario.objects.get_or_create(
+            email='joao.morador@exemplo.com',
+            defaults={'nome': 'João da Silva', 'perfil': 'morador', 'ativo': True}
+        )
+        if c:
+            morador.set_password('senha123')
+            morador.save()
+        self.stdout.write(f"✓ Morador {morador.email}: {'Criado' if c else 'Já existia'}")
+
+        # 5. Imóvel
+        imovel, c = Imovel.objects.get_or_create(
+            inscricao='IPTU-123456',
+            defaults={
+                'titular': morador, 'cep': '59900-000', 'logradouro': 'Rua Teste', 
+                'numero': '123', 'bairro': 'Centro', 'cidade': 'Natal', 'estado': 'RN', 
+                'num_moradores': 3, 'ativo': True
+            }
+        )
+        self.stdout.write(f"✓ Imóvel {imovel.inscricao}: {'Criado' if c else 'Já existia'}")
+
+        # 6. Coleta e Saldo (Sempre cria nova para simular acúmulo)
+        id_coleta = f'MANUAL-{int(time.time())}'
+        RegistroColeta.objects.create(
+            id_microservico=id_coleta, imovel=imovel, programa=programa, 
+            peso_kg=Decimal('10.00'), pontuacao=Decimal('15.00'), data_hora_coleta=timezone.now()
+        )
+        self.stdout.write(f"✓ Nova coleta registrada: {id_coleta}")
+
+        ciclo = hoje.strftime('%m-%Y')
+        saldo, c = SaldoPontos.objects.get_or_create(
+            imovel=imovel, programa=programa, ciclo=ciclo,
+            defaults={'desconto_percentual': Decimal('1.50')}
+        )
+        if not c:
+            saldo.desconto_percentual += Decimal('1.50')
+            saldo.save()
+            self.stdout.write(f"✓ Saldo acumulado! Atual: {saldo.desconto_percentual}%")
+        else:
+            self.stdout.write(f"✓ Saldo inicial criado: {saldo.desconto_percentual}%")
+
+        self.stdout.write("=== CONCLUÍDO COM SUCESSO ===")

--- a/core/program/management/commands/test_llm_report.py
+++ b/core/program/management/commands/test_llm_report.py
@@ -24,9 +24,9 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"✗ Erro na extração: {e}"))
             return
 
-        self.stdout.write("\n--- Testando chamada ao LLM (Claude) ---")
+        self.stdout.write("\n--- Testando chamada ao LLM (DeepSeek) ---")
         if not service.api_key:
-            self.stdout.write(self.style.WARNING("! Pulando chamada à API: ANTHROPIC_API_KEY não configurada."))
+            self.stdout.write(self.style.WARNING("! Pulando chamada à API: DEEPSEEK_API_KEY não configurada."))
         else:
             relatorio = service.gerar_relatorio_narrativo("Relatório de Impacto Mensal", inicio, fim)
             self.stdout.write("\nResultado do LLM:\n")

--- a/core/program/management/commands/test_llm_report.py
+++ b/core/program/management/commands/test_llm_report.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from datetime import timedelta
+import json
+from reports.llm_service import LLMReportService
+
+class Command(BaseCommand):
+    help = 'Testa a extração de dados e a integração com LLM para relatórios'
+
+    def handle(self, *args, **options):
+        service = LLMReportService()
+        
+        # Define um período de teste (últimos 30 dias)
+        fim = timezone.now()
+        inicio = fim - timedelta(days=30)
+        
+        self.stdout.write(f"--- Testando extração de dados ({inicio.date()} até {fim.date()}) ---")
+        
+        try:
+            dados = service.extrair_dados_do_banco(inicio, fim)
+            self.stdout.write(json.dumps(dados, indent=2, ensure_ascii=False))
+            self.stdout.write(self.style.SUCCESS("✓ Extração de dados concluída com sucesso!"))
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"✗ Erro na extração: {e}"))
+            return
+
+        self.stdout.write("\n--- Testando chamada ao LLM (Claude) ---")
+        if not service.api_key:
+            self.stdout.write(self.style.WARNING("! Pulando chamada à API: ANTHROPIC_API_KEY não configurada."))
+        else:
+            relatorio = service.gerar_relatorio_narrativo("Relatório de Impacto Mensal", inicio, fim)
+            self.stdout.write("\nResultado do LLM:\n")
+            self.stdout.write(relatorio)

--- a/core/program/management/commands/test_local_llm_report.py
+++ b/core/program/management/commands/test_local_llm_report.py
@@ -1,0 +1,52 @@
+import json
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from reports.local_llm_service import LocalLLMReportService
+
+
+class Command(BaseCommand):
+    help = 'Testa extração de dados e integração com LLM local (LM Studio)'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dias', type=int, default=30,
+            help='Período de análise em dias (padrão: 30)',
+        )
+        parser.add_argument(
+            '--tipo', default='Relatório de Impacto Mensal',
+            help='Tipo de relatório a ser gerado',
+        )
+
+    def handle(self, *args, **options):
+        service = LocalLLMReportService()
+        fim = timezone.now()
+        inicio = fim - timedelta(days=options['dias'])
+
+        self.stdout.write(
+            f"LLM local: {service.model}  |  endpoint: {service.endpoint}"
+        )
+        self.stdout.write(
+            f"Período: {inicio.date()} → {fim.date()}"
+        )
+        self.stdout.write("─" * 60)
+
+        self.stdout.write("\n[1/2] Extraindo dados do banco...")
+        try:
+            dados = service.extrair_dados_do_banco(inicio, fim)
+            self.stdout.write(json.dumps(dados, indent=2, ensure_ascii=False))
+            self.stdout.write(self.style.SUCCESS("✓ Extração concluída"))
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"✗ Erro na extração: {e}"))
+            return
+
+        self.stdout.write(f"\n[2/2] Gerando relatório via LLM local...")
+        relatorio = service.gerar_relatorio_narrativo(options['tipo'], inicio, fim)
+
+        if relatorio.startswith("Erro"):
+            self.stdout.write(self.style.ERROR(relatorio))
+        else:
+            self.stdout.write(self.style.SUCCESS("✓ Relatório gerado:\n"))
+            self.stdout.write(relatorio)

--- a/core/reports/llm_service.py
+++ b/core/reports/llm_service.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from django.db.models import Sum, Count, Avg
+from django.conf import settings
+from django.utils import timezone
+import anthropic
+
+from collection.models import RegistroColeta
+from program.models import Imovel, SaldoPontos
+
+logger = logging.getLogger(__name__)
+
+class LLMReportService:
+    """
+    Serviço de integração com LLM (Anthropic) para geração de relatórios narrativos.
+    """
+
+    def __init__(self):
+        self.api_key = settings.ANTHROPIC_API_KEY
+        if not self.api_key:
+            logger.warning("ANTHROPIC_API_KEY não configurada no settings.")
+            self.client = None
+        else:
+            self.client = anthropic.Anthropic(api_key=self.api_key)
+
+    def extrair_dados_do_banco(self, data_inicio, data_fim):
+        """
+        Consulta e agrega dados relevantes do banco para o período informado.
+        """
+        # Filtro base para o período
+        coletas_qs = RegistroColeta.objects.filter(
+            data_hora_coleta__range=(data_inicio, data_fim)
+        )
+
+        # Agregações gerais
+        metrics = coletas_qs.aggregate(
+            total_peso=Sum('peso_kg'),
+            total_pontos=Sum('pontuacao'),
+            total_coletas=Count('id'),
+            total_imoveis_participantes=Count('imovel', distinct=True)
+        )
+
+        # Top 5 bairros mais engajados (por peso)
+        top_bairros = (
+            coletas_qs.values('imovel__bairro')
+            .annotate(peso=Sum('peso_kg'))
+            .order_by('-peso')[:5]
+        )
+
+        # Resumo de descontos no período (SaldoPontos)
+        # Nota: SaldoPontos é por ciclo (MM-YYYY). Vamos pegar os do período aproximado.
+        saldos_qs = SaldoPontos.objects.filter(atualizado__range=(data_inicio, data_fim))
+        descontos_metrics = saldos_qs.aggregate(
+            media_desconto=Avg('desconto_percentual'),
+            max_desconto=Sum('desconto_percentual') # Somatório de % não faz muito sentido sem contexto, mas serve de métrica
+        )
+
+        return {
+            "periodo": {
+                "inicio": data_inicio.isoformat(),
+                "fim": data_fim.isoformat()
+            },
+            "metricas_gerais": {
+                "total_peso_kg": float(metrics['total_peso'] or 0),
+                "total_pontos_gerados": float(metrics['total_pontos'] or 0),
+                "quantidade_coletas": metrics['total_coletas'],
+                "imoveis_unicos_participantes": metrics['total_imoveis_participantes']
+            },
+            "top_bairros": [
+                {"bairro": b['imovel__bairro'], "peso_kg": float(b['peso'])}
+                for b in top_bairros
+            ],
+            "descontos_iptu": {
+                "media_percentual_desconto": float(descontos_metrics['media_desconto'] or 0)
+            }
+        }
+
+    def gerar_relatorio_narrativo(self, tipo_relatorio: str, data_inicio, data_fim) -> str:
+        """
+        Monta o prompt, envia ao LLM e retorna o relatório em texto narrativo.
+        Utiliza Prompt Caching para reduzir custos.
+        """
+        if not self.client:
+            return "Erro: API Key da Anthropic não configurada."
+
+        # 1. Extrai dados do banco
+        dados = self.extrair_dados_do_banco(data_inicio, data_fim)
+
+        # 2. Define a mensagem de sistema com Cache Control
+        # Instruções detalhadas para garantir um bom tom e formatação.
+        system_content = [
+            {
+                "type": "text",
+                "text": (
+                    "Você é um consultor analítico do programa 'Coleta Premiada'. "
+                    "Sua missão é transformar dados técnicos de reciclagem em relatórios narrativos inspiradores e informativos. "
+                    "Use um tom profissional, mas encorajador. "
+                    "Sempre formate o relatório em Markdown, usando títulos, listas e negrito para destacar pontos chave. "
+                    "Analise tendências, destaque o impacto ambiental (conversão de lixo em benefício) e o impacto social (desconto no IPTU)."
+                ),
+                "cache_control": {"type": "ephemeral"} # Tag de cache para economizar tokens
+            }
+        ]
+
+        # 3. Define o prompt do usuário com os dados
+        user_prompt = (
+            f"Por favor, gere um relatório do tipo: '{tipo_relatorio}'.\n\n"
+            f"Dados estatísticos coletados:\n{json.dumps(dados, indent=2)}\n\n"
+            "Escreva uma análise profunda, não apenas repita os números. "
+            "Sugira melhorias se os números estiverem baixos ou parabenize se estiverem altos."
+        )
+
+        try:
+            # 4. Chamada à API (Claude 3.5 Haiku)
+            response = self.client.messages.create(
+                model="claude-3-5-haiku-20241022",
+                max_tokens=2048,
+                system=system_content,
+                messages=[
+                    {"role": "user", "content": user_prompt}
+                ]
+            )
+
+            return response.content[0].text
+        except Exception as e:
+            logger.error(f"Erro ao chamar API Anthropic: {e}")
+            return f"Erro ao gerar relatório: {str(e)}"

--- a/core/reports/llm_service.py
+++ b/core/reports/llm_service.py
@@ -111,14 +111,27 @@ class LLMReportService:
         )
 
         try:
-            # 4. Chamada à API (Claude 3.5 Haiku)
+            # 4. Chamada à API (Claude Sonnet 4.6)
             response = self.client.messages.create(
-                model="claude-3-5-haiku-20241022",
+                model="claude-sonnet-4-6",
                 max_tokens=2048,
                 system=system_content,
                 messages=[
                     {"role": "user", "content": user_prompt}
                 ]
+            )
+
+            # Log de uso para validar o prompt caching (cache_control).
+            # Numa 2ª chamada com o mesmo prefixo (TTL 5 min), cache_read > 0
+            # confirma o cache hit. Se ambos ficarem 0, o system prompt está
+            # abaixo do mínimo cacheável do modelo (2048 tokens no Sonnet 4.6).
+            usage = response.usage
+            logger.info(
+                "LLM usage | input=%s cache_write=%s cache_read=%s output=%s",
+                usage.input_tokens,
+                usage.cache_creation_input_tokens,
+                usage.cache_read_input_tokens,
+                usage.output_tokens,
             )
 
             return response.content[0].text

--- a/core/reports/llm_service.py
+++ b/core/reports/llm_service.py
@@ -3,7 +3,7 @@ import logging
 from django.db.models import Sum, Count, Avg
 from django.conf import settings
 from django.utils import timezone
-import anthropic
+import openai
 
 from collection.models import RegistroColeta
 from program.models import Imovel, SaldoPontos
@@ -12,27 +12,28 @@ logger = logging.getLogger(__name__)
 
 class LLMReportService:
     """
-    Serviço de integração com LLM (Anthropic) para geração de relatórios narrativos.
+    Serviço de integração com LLM (DeepSeek) para geração de relatórios narrativos.
     """
 
     def __init__(self):
-        self.api_key = settings.ANTHROPIC_API_KEY
+        self.api_key = settings.DEEPSEEK_API_KEY
         if not self.api_key:
-            logger.warning("ANTHROPIC_API_KEY não configurada no settings.")
+            logger.warning("DEEPSEEK_API_KEY não configurada no settings.")
             self.client = None
         else:
-            self.client = anthropic.Anthropic(api_key=self.api_key)
+            self.client = openai.OpenAI(
+                api_key=self.api_key,
+                base_url="https://api.deepseek.com",
+            )
 
     def extrair_dados_do_banco(self, data_inicio, data_fim):
         """
         Consulta e agrega dados relevantes do banco para o período informado.
         """
-        # Filtro base para o período
         coletas_qs = RegistroColeta.objects.filter(
             data_hora_coleta__range=(data_inicio, data_fim)
         )
 
-        # Agregações gerais
         metrics = coletas_qs.aggregate(
             total_peso=Sum('peso_kg'),
             total_pontos=Sum('pontuacao'),
@@ -40,19 +41,16 @@ class LLMReportService:
             total_imoveis_participantes=Count('imovel', distinct=True)
         )
 
-        # Top 5 bairros mais engajados (por peso)
         top_bairros = (
             coletas_qs.values('imovel__bairro')
             .annotate(peso=Sum('peso_kg'))
             .order_by('-peso')[:5]
         )
 
-        # Resumo de descontos no período (SaldoPontos)
-        # Nota: SaldoPontos é por ciclo (MM-YYYY). Vamos pegar os do período aproximado.
         saldos_qs = SaldoPontos.objects.filter(atualizado__range=(data_inicio, data_fim))
         descontos_metrics = saldos_qs.aggregate(
             media_desconto=Avg('desconto_percentual'),
-            max_desconto=Sum('desconto_percentual') # Somatório de % não faz muito sentido sem contexto, mas serve de métrica
+            max_desconto=Sum('desconto_percentual')
         )
 
         return {
@@ -77,32 +75,21 @@ class LLMReportService:
 
     def gerar_relatorio_narrativo(self, tipo_relatorio: str, data_inicio, data_fim) -> str:
         """
-        Monta o prompt, envia ao LLM e retorna o relatório em texto narrativo.
-        Utiliza Prompt Caching para reduzir custos.
+        Monta o prompt, envia ao DeepSeek e retorna o relatório em texto narrativo.
         """
         if not self.client:
-            return "Erro: API Key da Anthropic não configurada."
+            return "Erro: API Key do DeepSeek não configurada."
 
-        # 1. Extrai dados do banco
         dados = self.extrair_dados_do_banco(data_inicio, data_fim)
 
-        # 2. Define a mensagem de sistema com Cache Control
-        # Instruções detalhadas para garantir um bom tom e formatação.
-        system_content = [
-            {
-                "type": "text",
-                "text": (
-                    "Você é um consultor analítico do programa 'Coleta Premiada'. "
-                    "Sua missão é transformar dados técnicos de reciclagem em relatórios narrativos inspiradores e informativos. "
-                    "Use um tom profissional, mas encorajador. "
-                    "Sempre formate o relatório em Markdown, usando títulos, listas e negrito para destacar pontos chave. "
-                    "Analise tendências, destaque o impacto ambiental (conversão de lixo em benefício) e o impacto social (desconto no IPTU)."
-                ),
-                "cache_control": {"type": "ephemeral"} # Tag de cache para economizar tokens
-            }
-        ]
+        system_prompt = (
+            "Você é um consultor analítico do programa 'Coleta Premiada'. "
+            "Sua missão é transformar dados técnicos de reciclagem em relatórios narrativos inspiradores e informativos. "
+            "Use um tom profissional, mas encorajador. "
+            "Sempre formate o relatório em Markdown, usando títulos, listas e negrito para destacar pontos chave. "
+            "Analise tendências, destaque o impacto ambiental (conversão de lixo em benefício) e o impacto social (desconto no IPTU)."
+        )
 
-        # 3. Define o prompt do usuário com os dados
         user_prompt = (
             f"Por favor, gere um relatório do tipo: '{tipo_relatorio}'.\n\n"
             f"Dados estatísticos coletados:\n{json.dumps(dados, indent=2)}\n\n"
@@ -111,30 +98,24 @@ class LLMReportService:
         )
 
         try:
-            # 4. Chamada à API (Claude Sonnet 4.6)
-            response = self.client.messages.create(
-                model="claude-sonnet-4-6",
+            response = self.client.chat.completions.create(
+                model="deepseek-chat",
                 max_tokens=2048,
-                system=system_content,
                 messages=[
-                    {"role": "user", "content": user_prompt}
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
                 ]
             )
 
-            # Log de uso para validar o prompt caching (cache_control).
-            # Numa 2ª chamada com o mesmo prefixo (TTL 5 min), cache_read > 0
-            # confirma o cache hit. Se ambos ficarem 0, o system prompt está
-            # abaixo do mínimo cacheável do modelo (2048 tokens no Sonnet 4.6).
             usage = response.usage
             logger.info(
-                "LLM usage | input=%s cache_write=%s cache_read=%s output=%s",
-                usage.input_tokens,
-                usage.cache_creation_input_tokens,
-                usage.cache_read_input_tokens,
-                usage.output_tokens,
+                "LLM usage | prompt_tokens=%s completion_tokens=%s total_tokens=%s",
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                usage.total_tokens,
             )
 
-            return response.content[0].text
+            return response.choices[0].message.content
         except Exception as e:
-            logger.error(f"Erro ao chamar API Anthropic: {e}")
+            logger.error(f"Erro ao chamar API DeepSeek: {e}")
             return f"Erro ao gerar relatório: {str(e)}"

--- a/core/reports/local_llm_service.py
+++ b/core/reports/local_llm_service.py
@@ -1,0 +1,134 @@
+import json
+import logging
+import urllib.request
+import urllib.error
+from django.db.models import Sum, Count, Avg
+from django.conf import settings
+
+from collection.models import RegistroColeta
+from program.models import SaldoPontos
+
+logger = logging.getLogger(__name__)
+
+
+class LocalLLMReportService:
+    """
+    Serviço de relatórios narrativos usando LLM local via LM Studio.
+    Compatível com a API OpenAI (POST /v1/chat/completions).
+    """
+
+    def __init__(self):
+        self.base_url = getattr(settings, 'LOCAL_LLM_BASE_URL', 'http://127.0.0.1:1234')
+        self.model = getattr(settings, 'LOCAL_LLM_MODEL', 'google/gemma-4-e2b')
+        self.endpoint = f"{self.base_url}/v1/chat/completions"
+
+    def extrair_dados_do_banco(self, data_inicio, data_fim):
+        """
+        Consulta e agrega dados relevantes do banco para o período informado.
+        Idêntico ao LLMReportService — reutilizável sem depender da API Anthropic.
+        """
+        coletas_qs = RegistroColeta.objects.filter(
+            data_hora_coleta__range=(data_inicio, data_fim)
+        )
+
+        metrics = coletas_qs.aggregate(
+            total_peso=Sum('peso_kg'),
+            total_pontos=Sum('pontuacao'),
+            total_coletas=Count('id'),
+            total_imoveis_participantes=Count('imovel', distinct=True),
+        )
+
+        top_bairros = (
+            coletas_qs.values('imovel__bairro')
+            .annotate(peso=Sum('peso_kg'))
+            .order_by('-peso')[:5]
+        )
+
+        saldos_qs = SaldoPontos.objects.filter(atualizado__range=(data_inicio, data_fim))
+        descontos_metrics = saldos_qs.aggregate(
+            media_desconto=Avg('desconto_percentual'),
+        )
+
+        return {
+            "periodo": {
+                "inicio": data_inicio.isoformat(),
+                "fim": data_fim.isoformat(),
+            },
+            "metricas_gerais": {
+                "total_peso_kg": float(metrics['total_peso'] or 0),
+                "total_pontos_gerados": float(metrics['total_pontos'] or 0),
+                "quantidade_coletas": metrics['total_coletas'],
+                "imoveis_unicos_participantes": metrics['total_imoveis_participantes'],
+            },
+            "top_bairros": [
+                {"bairro": b['imovel__bairro'], "peso_kg": float(b['peso'])}
+                for b in top_bairros
+            ],
+            "descontos_iptu": {
+                "media_percentual_desconto": float(descontos_metrics['media_desconto'] or 0),
+            },
+        }
+
+    def _chamar_llm(self, system_prompt: str, user_prompt: str) -> str:
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "max_tokens": 2048,
+            "temperature": 0.7,
+        }
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self.endpoint,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+
+        text = result["choices"][0]["message"]["content"]
+        usage = result.get("usage", {})
+        logger.info(
+            "Local LLM usage | prompt_tokens=%s completion_tokens=%s total_tokens=%s",
+            usage.get("prompt_tokens"),
+            usage.get("completion_tokens"),
+            usage.get("total_tokens"),
+        )
+        return text
+
+    def gerar_relatorio_narrativo(self, tipo_relatorio: str, data_inicio, data_fim) -> str:
+        """
+        Extrai dados do banco, monta o prompt e chama o LLM local via LM Studio.
+        """
+        dados = self.extrair_dados_do_banco(data_inicio, data_fim)
+
+        system_prompt = (
+            "Você é um consultor analítico do programa 'Coleta Premiada'. "
+            "Sua missão é transformar dados técnicos de reciclagem em relatórios narrativos "
+            "inspiradores e informativos. Use um tom profissional, mas encorajador. "
+            "Sempre formate o relatório em Markdown, usando títulos, listas e negrito para "
+            "destacar pontos chave. Analise tendências, destaque o impacto ambiental "
+            "(conversão de lixo em benefício) e o impacto social (desconto no IPTU)."
+        )
+
+        user_prompt = (
+            f"Por favor, gere um relatório do tipo: '{tipo_relatorio}'.\n\n"
+            f"Dados estatísticos coletados:\n{json.dumps(dados, indent=2, ensure_ascii=False)}\n\n"
+            "Escreva uma análise profunda, não apenas repita os números. "
+            "Sugira melhorias se os números estiverem baixos ou parabenize se estiverem altos."
+        )
+
+        try:
+            return self._chamar_llm(system_prompt, user_prompt)
+        except urllib.error.URLError as e:
+            logger.error("LM Studio inacessível em %s: %s", self.endpoint, e)
+            return f"Erro: LM Studio não está respondendo em {self.endpoint}. Verifique se o servidor está rodando."
+        except (KeyError, IndexError, json.JSONDecodeError) as e:
+            logger.error("Resposta inesperada do LLM local: %s", e)
+            return f"Erro: resposta inesperada do LLM local — {e}"
+        except Exception as e:
+            logger.error("Erro ao chamar LLM local: %s", e)
+            return f"Erro ao gerar relatório: {e}"

--- a/core/reports/tests.py
+++ b/core/reports/tests.py
@@ -1,0 +1,160 @@
+"""
+Testes do serviço de relatórios via LLM (reports.llm_service).
+
+Cobertura:
+  - extrair_dados_do_banco: agregações sobre coletas/saldos no período.
+  - gerar_relatorio_narrativo: monta o prompt correto (modelo, cache_control,
+    dados em JSON) usando o cliente Anthropic MOCKADO — sem custo e sem API key.
+  - comportamento sem ANTHROPIC_API_KEY configurada.
+
+Rodar:
+    python manage.py test reports
+"""
+import json
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from accounts.models import Usuario
+from program.models import Imovel, Programa, SaldoPontos
+from collection.models import RegistroColeta
+from reports.llm_service import LLMReportService
+
+
+def _criar_imovel(inscricao, bairro, titular):
+    return Imovel.objects.create(
+        inscricao=inscricao,
+        titular=titular,
+        cep="60000-000",
+        logradouro="Rua das Flores",
+        numero="100",
+        bairro=bairro,
+        cidade="Fortaleza",
+        estado="CE",
+    )
+
+
+@override_settings(ANTHROPIC_API_KEY="test-key")
+class ExtrairDadosDoBancoTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # 'fim' com folga p/ frente: SaldoPontos.atualizado é auto_now (gravado
+        # em now() ao salvar, logo após este ponto) e precisa cair na janela.
+        cls.fim = timezone.now() + timedelta(minutes=5)
+        cls.inicio = cls.fim - timedelta(days=30)
+        dentro = timezone.now() - timedelta(days=1)
+
+        morador = Usuario.objects.create_user(
+            email="morador@example.com", password="x", nome="Morador", perfil="morador",
+        )
+        cls.programa = Programa.objects.create(
+            nome="Coleta Premiada 2026",
+            data_inicio=cls.inicio.date(),
+            data_fim=cls.fim.date(),
+        )
+
+        imovel_centro = _criar_imovel("INSC-1", "Centro", morador)
+        imovel_beira = _criar_imovel("INSC-2", "Beira-Mar", morador)
+
+        # Coletas DENTRO da janela: Centro = 10+5 = 15 kg; Beira-Mar = 20 kg.
+        RegistroColeta.objects.create(
+            id_microservico="m1", imovel=imovel_centro, peso_kg=Decimal("10.000"),
+            pontuacao=Decimal("15.00"), data_hora_coleta=dentro,
+        )
+        RegistroColeta.objects.create(
+            id_microservico="m2", imovel=imovel_centro, peso_kg=Decimal("5.000"),
+            pontuacao=Decimal("7.50"), data_hora_coleta=dentro,
+        )
+        RegistroColeta.objects.create(
+            id_microservico="m3", imovel=imovel_beira, peso_kg=Decimal("20.000"),
+            pontuacao=Decimal("30.00"), data_hora_coleta=dentro,
+        )
+        # Coleta FORA da janela — não deve entrar nas métricas.
+        RegistroColeta.objects.create(
+            id_microservico="m4", imovel=imovel_centro, peso_kg=Decimal("999.000"),
+            pontuacao=Decimal("999.00"), data_hora_coleta=cls.fim - timedelta(days=400),
+        )
+
+        # SaldoPontos: 'atualizado' é auto_now => grava now() (dentro da janela).
+        SaldoPontos.objects.create(
+            imovel=imovel_centro, programa=cls.programa, ciclo="06-2026",
+            desconto_percentual=Decimal("12.50"),
+        )
+        SaldoPontos.objects.create(
+            imovel=imovel_beira, programa=cls.programa, ciclo="06-2026",
+            desconto_percentual=Decimal("7.50"),
+        )
+
+    def test_metricas_gerais(self):
+        dados = LLMReportService().extrair_dados_do_banco(self.inicio, self.fim)
+        m = dados["metricas_gerais"]
+        self.assertAlmostEqual(m["total_peso_kg"], 35.0)
+        self.assertAlmostEqual(m["total_pontos_gerados"], 52.5)
+        self.assertEqual(m["quantidade_coletas"], 3)
+        self.assertEqual(m["imoveis_unicos_participantes"], 2)
+
+    def test_top_bairros_ordenado_por_peso(self):
+        dados = LLMReportService().extrair_dados_do_banco(self.inicio, self.fim)
+        bairros = dados["top_bairros"]
+        self.assertEqual(bairros[0]["bairro"], "Beira-Mar")
+        self.assertAlmostEqual(bairros[0]["peso_kg"], 20.0)
+        self.assertEqual(bairros[1]["bairro"], "Centro")
+        self.assertAlmostEqual(bairros[1]["peso_kg"], 15.0)
+
+    def test_media_desconto_iptu(self):
+        dados = LLMReportService().extrair_dados_do_banco(self.inicio, self.fim)
+        self.assertAlmostEqual(dados["descontos_iptu"]["media_percentual_desconto"], 10.0)
+
+    def test_periodo_vazio_retorna_zeros(self):
+        fim = self.fim - timedelta(days=365)
+        inicio = fim - timedelta(days=30)
+        dados = LLMReportService().extrair_dados_do_banco(inicio, fim)
+        m = dados["metricas_gerais"]
+        self.assertEqual(m["total_peso_kg"], 0.0)
+        self.assertEqual(m["total_pontos_gerados"], 0.0)
+        self.assertEqual(m["quantidade_coletas"], 0)
+        self.assertEqual(m["imoveis_unicos_participantes"], 0)
+        self.assertEqual(dados["top_bairros"], [])
+        self.assertEqual(dados["descontos_iptu"]["media_percentual_desconto"], 0.0)
+
+
+@override_settings(ANTHROPIC_API_KEY="test-key")
+class GerarRelatorioNarrativoTests(TestCase):
+    @patch("reports.llm_service.anthropic.Anthropic")
+    def test_monta_prompt_modelo_e_cache_control(self, mock_anthropic_cls):
+        mock_client = mock_anthropic_cls.return_value
+        mock_resp = MagicMock()
+        mock_resp.content = [MagicMock(text="Relatório narrativo gerado.")]
+        mock_client.messages.create.return_value = mock_resp
+
+        fim = timezone.now()
+        inicio = fim - timedelta(days=30)
+        texto = LLMReportService().gerar_relatorio_narrativo(
+            "Relatório de Impacto Mensal", inicio, fim,
+        )
+
+        self.assertEqual(texto, "Relatório narrativo gerado.")
+        self.assertEqual(mock_client.messages.create.call_count, 1)
+
+        kwargs = mock_client.messages.create.call_args.kwargs
+        # Modelo exigido pela task.
+        self.assertEqual(kwargs["model"], "claude-sonnet-4-6")
+        # cache_control no system prompt (prompt caching).
+        self.assertEqual(kwargs["system"][0]["cache_control"], {"type": "ephemeral"})
+        # Dados em JSON dentro do prompt do usuário.
+        user_content = kwargs["messages"][0]["content"]
+        self.assertIn("metricas_gerais", user_content)
+        self.assertIn("Relatório de Impacto Mensal", user_content)
+        # JSON válido embutido no prompt.
+        self.assertIn(json.dumps({"inicio": inicio.isoformat()})[1:-1], user_content)
+
+    @override_settings(ANTHROPIC_API_KEY=None)
+    def test_sem_api_key_retorna_erro_sem_chamar_api(self):
+        service = LLMReportService()
+        self.assertIsNone(service.client)
+        fim = timezone.now()
+        texto = service.gerar_relatorio_narrativo("X", fim - timedelta(days=30), fim)
+        self.assertIn("API Key", texto)

--- a/core/reports/tests.py
+++ b/core/reports/tests.py
@@ -3,9 +3,9 @@ Testes do serviço de relatórios via LLM (reports.llm_service).
 
 Cobertura:
   - extrair_dados_do_banco: agregações sobre coletas/saldos no período.
-  - gerar_relatorio_narrativo: monta o prompt correto (modelo, cache_control,
-    dados em JSON) usando o cliente Anthropic MOCKADO — sem custo e sem API key.
-  - comportamento sem ANTHROPIC_API_KEY configurada.
+  - gerar_relatorio_narrativo: monta o prompt correto (modelo, dados em JSON)
+    usando o cliente DeepSeek MOCKADO — sem custo e sem API key.
+  - comportamento sem DEEPSEEK_API_KEY configurada.
 
 Rodar:
     python manage.py test reports
@@ -37,7 +37,7 @@ def _criar_imovel(inscricao, bairro, titular):
     )
 
 
-@override_settings(ANTHROPIC_API_KEY="test-key")
+@override_settings(DEEPSEEK_API_KEY="test-key")
 class ExtrairDadosDoBancoTests(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -121,14 +121,15 @@ class ExtrairDadosDoBancoTests(TestCase):
         self.assertEqual(dados["descontos_iptu"]["media_percentual_desconto"], 0.0)
 
 
-@override_settings(ANTHROPIC_API_KEY="test-key")
+@override_settings(DEEPSEEK_API_KEY="test-key")
 class GerarRelatorioNarrativoTests(TestCase):
-    @patch("reports.llm_service.anthropic.Anthropic")
-    def test_monta_prompt_modelo_e_cache_control(self, mock_anthropic_cls):
-        mock_client = mock_anthropic_cls.return_value
+    @patch("reports.llm_service.openai.OpenAI")
+    def test_monta_prompt_e_modelo(self, mock_openai_cls):
+        mock_client = mock_openai_cls.return_value
         mock_resp = MagicMock()
-        mock_resp.content = [MagicMock(text="Relatório narrativo gerado.")]
-        mock_client.messages.create.return_value = mock_resp
+        mock_resp.choices = [MagicMock(message=MagicMock(content="Relatório narrativo gerado."))]
+        mock_resp.usage = MagicMock(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        mock_client.chat.completions.create.return_value = mock_resp
 
         fim = timezone.now()
         inicio = fim - timedelta(days=30)
@@ -137,21 +138,19 @@ class GerarRelatorioNarrativoTests(TestCase):
         )
 
         self.assertEqual(texto, "Relatório narrativo gerado.")
-        self.assertEqual(mock_client.messages.create.call_count, 1)
+        self.assertEqual(mock_client.chat.completions.create.call_count, 1)
 
-        kwargs = mock_client.messages.create.call_args.kwargs
-        # Modelo exigido pela task.
-        self.assertEqual(kwargs["model"], "claude-sonnet-4-6")
-        # cache_control no system prompt (prompt caching).
-        self.assertEqual(kwargs["system"][0]["cache_control"], {"type": "ephemeral"})
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        self.assertEqual(kwargs["model"], "deepseek-chat")
+        # System prompt na primeira mensagem.
+        self.assertEqual(kwargs["messages"][0]["role"], "system")
         # Dados em JSON dentro do prompt do usuário.
-        user_content = kwargs["messages"][0]["content"]
+        user_content = kwargs["messages"][1]["content"]
         self.assertIn("metricas_gerais", user_content)
         self.assertIn("Relatório de Impacto Mensal", user_content)
-        # JSON válido embutido no prompt.
         self.assertIn(json.dumps({"inicio": inicio.isoformat()})[1:-1], user_content)
 
-    @override_settings(ANTHROPIC_API_KEY=None)
+    @override_settings(DEEPSEEK_API_KEY=None)
     def test_sem_api_key_retorna_erro_sem_chamar_api(self):
         service = LLMReportService()
         self.assertIsNone(service.client)

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -9,4 +9,4 @@ python-dotenv==1.2.2
 django-auditlog==3.4.1
 geopy==2.4.1
 celery==5.4.0
-anthropic>=0.42.0
+openai>=1.0.0

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -9,3 +9,4 @@ python-dotenv==1.2.2
 django-auditlog==3.4.1
 geopy==2.4.1
 celery==5.4.0
+anthropic>=0.42.0


### PR DESCRIPTION
### Issue: [LLM-1]

---
Módulo reports/ — geração de relatórios narrativos via LLM

Cria o módulo core/reports/ com dois serviços que extraem dados do banco (coletas, pontuações, descontos de IPTU) e geram relatórios narrativos em Markdown via LLM.

---
LLMReportService — integração com Anthropic (Claude)

- Extrai e agrega dados do banco por período: peso total, pontos, top bairros, média de desconto IPTU
- Monta prompt estruturado em JSON com cache_control: ephemeral para prompt caching
- Modelo: claude-sonnet-4-6
- Log de usage (input / cache_write / cache_read / output tokens) para validar se o cache engata
- sem ANTHROPIC_API_KEY: retorna mensagem de erro

LocalLLMReportService — integração com LLM local via LM Studio

- Mesma lógica de extração do LLMReportService
- Chamada HTTP via urllib (stdlib — sem nova dependência) ao endpoint OpenAI-compatible do LM Studio
- Configurável via env: LOCAL_LLM_BASE_URL / LOCAL_LLM_MODEL
- Testado com google/gemma-4-e2b em http://host.docker.internal:1234
- Erros de rede/resposta tratados individualmente com mensagens descritivas

---
Testes automatizados

core/reports/tests.py — 6 testes com cliente Anthropic mockado (sem API key, sem custo):

---
Configuração (variáveis opcionais no .env)

LOCAL_LLM_BASE_URL=http://host.docker.internal:1234
LOCAL_LLM_MODEL=google/gemma-4-e2b

---
Como testar

# Testes automatizados (sem API key)
docker compose exec core python manage.py test reports

# Smoke test com LM Studio rodando
docker compose exec core python manage.py test_local_llm_report

# Smoke test com ANTHROPIC_API_KEY configurada no .env
docker compose exec core python manage.py test_llm_report

---
Arquivos alterados

core/reports/__init__.py
core/reports/llm_service.py               (serviço Anthropic + troca de modelo)
core/reports/local_llm_service.py         (serviço LM Studio)
core/reports/tests.py                     (6 testes automatizados)
core/config/settings.py                   (LOCAL_LLM_BASE_URL, LOCAL_LLM_MODEL, ANTHROPIC_API_KEY)
core/requirements.txt                     (anthropic>=0.42.0)
core/program/management/commands/test_llm_report.py
core/program/management/commands/test_local_llm_report.py